### PR TITLE
Fix encoding error in utils.py

### DIFF
--- a/lol/model/utils.py
+++ b/lol/model/utils.py
@@ -141,7 +141,7 @@ def _match_ips(text):
 class SimilarityLabelGenerator:
     def __init__(self, filename: str, platform='linux'):
         self._platform = platform
-        lines = open(filename).readlines()
+        lines = open(filename, encoding='utf-8').readlines()
         self._strings = []
         for s in lines:
             # s = s[:min(150, len(s))]


### PR DESCRIPTION
## Description

First off, this is my first pull request, so please pardon me if I've forgotten anything or failed to follow the contribution guidelines correctly! Thanks.

Running the WINDOWS example for this repo, I get the following error:
```python
Traceback (most recent call last):
  File "<pyshell#1>", line 1, in <module>
    lolc=LOLC(PlatformType.WINDOWS)
  File "C:\Users\sysmcb\AppData\Local\Programs\Python\Python39\lib\site-packages\lol\api.py", line 51, in __init__
    fte = WindowsFeatureExtraction(base_path=base_path)
  File "C:\Users\sysmcb\AppData\Local\Programs\Python\Python39\lib\site-packages\lol\model\utils.py", line 259, in __init__
    self._similarity = SimilarityLabelGenerator('{0}.known'.format(base_path), platform='windows')
  File "C:\Users\sysmcb\AppData\Local\Programs\Python\Python39\lib\site-packages\lol\model\utils.py", line 144, in __init__
    lines = open(filename).readlines()
  File "C:\Users\sysmcb\AppData\Local\Programs\Python\Python39\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 3667: character maps to <undefined>
```

Researching the error, I found the following: [Python 3 UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d](https://stackoverflow.com/questions/30750843/python-3-unicodedecodeerror-charmap-codec-cant-decode-byte-0x9d). From this, I gather that the default OS codec is used to open files, which for Windows is CP-1252. Therefore, it seemed the fix was to explicitly set the encoding used to open the file in Utils.py to be UTF-8. Modifying this fixed the error in my test environment.

## How Has This Been Tested?

I forked this repository, made the change in my local environment, and confirmed that I could successfully run the WINDOWS example code on this updated version.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have read the **CONTRIBUTING** document.
- [X ] I have added tests to cover my changes.
- [X ] All new and existing tests passed.
